### PR TITLE
Refactor: rename City to Cities::City.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ tar -xzf cities.tar.gz
 ```
 
 ```ruby
-City.data_path = '/path/to/cities'
+Cities.data_path = '/path/to/cities'
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ City.data_path = '/path/to/cities'
 Countries are identified by their [ISO 3166-1 alpha-2](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) codes.
 
 ```ruby
-cities = City.cities_in_country('GB')
+cities = Cities.cities_in_country('GB')
   #=> { "abberley"=> #<City:0x000001049b9ba0>, "abberton"=> #<City:0x000001049b9b50>, ... }
 
 mcr = cities['manchester']
@@ -43,7 +43,7 @@ mcr.latlong
 The database is exhaustive and certainly stretches the definition of the word "city".
 
 ```ruby
-City.cities_in_country('GB')['buchlyvie'].population
+Cities.cities_in_country('GB')['buchlyvie'].population
   #=> 448
 ```
 

--- a/lib/cities.rb
+++ b/lib/cities.rb
@@ -1,5 +1,42 @@
+require 'multi_json'
 require 'cities/city'
 require 'cities/country'
 
 module Cities
+  class << self
+    attr_accessor :data_path
+
+    def cities_in_country?(code)
+      File.exist?(path_for_country(code))
+    end
+    
+    def cities_in_country(code)
+      if self.cities_in_country?(code)
+        json = File.read(path_for_country(code))
+        country_data = MultiJson.load(json)
+        country_data.reduce({}) do |cities, city_data|
+          cities[city_data.first] = City.new(city_data.last)
+          cities
+        end
+      else
+        {}
+      end
+    end
+
+    private
+    def has_data?
+      data_path && Dir.exists?(data_path)
+    end
+
+    def path_for_country(code)
+      raise DataNotFound.new unless has_data?
+      File.join(data_path, "#{code}.json")
+    end
+  end
+
+  class DataNotFound < StandardError
+    def message
+      'JSON data not found. See README.md for installation instructions.'
+    end
+  end
 end

--- a/lib/cities/city.rb
+++ b/lib/cities/city.rb
@@ -1,80 +1,42 @@
-require 'multi_json'
+module Cities
 
-class City
-  
-  def initialize(data)
-    @data = data
-  end
-
-  def name
-    @data['accentcity']
-  end
-
-  def latitude
-    return nil if @data['latitude'].nil?
-    @data['latitude'].to_f
-  end
-
-  def longitude
-    return nil if @data['longitude'].nil?
-    @data['longitude'].to_f
-  end
-
-  def latlong?
-    latitude && longitude
-  end
-
-  def latlong
-    latlong? ? [latitude, longitude] : nil
-  end
-
-  def population
-    return nil if @data['population'].nil?
-    @data['population'].to_i
-  end
-
-  def region
-    @data['region']
-  end
-
-  class << self
-
-    attr_accessor :data_path
-
-    def cities_in_country?(code)
-      File.exist?(path_for_country(code))
-    end
+  class City
     
-    def cities_in_country(code)
-      if self.cities_in_country?(code)
-        json = File.read(path_for_country(code))
-        country_data = MultiJson.load(json)
-        country_data.reduce({}) do |cities, city_data|
-          cities[city_data.first] = City.new(city_data.last)
-          cities
-        end
-      else
-        {}
-      end
+    def initialize(data)
+      @data = data
     end
 
-    private
-
-      def has_data?
-        data_path && Dir.exists?(data_path)
-      end
-
-      def path_for_country(code)
-        raise DataNotFound.new unless has_data?
-        File.join(data_path, "#{code}.json")
-      end
-
-  end
-
-  class DataNotFound < StandardError
-    def message
-      'JSON data not found. See README.md for installation instructions.'
+    def name
+      @data['accentcity']
     end
+
+    def latitude
+      return nil if @data['latitude'].nil?
+      @data['latitude'].to_f
+    end
+
+    def longitude
+      return nil if @data['longitude'].nil?
+      @data['longitude'].to_f
+    end
+
+    def latlong?
+      latitude && longitude
+    end
+
+    def latlong
+      latlong? ? [latitude, longitude] : nil
+    end
+
+    def population
+      return nil if @data['population'].nil?
+      @data['population'].to_i
+    end
+
+    def region
+      @data['region']
+    end
+
   end
 
 end

--- a/lib/cities/country.rb
+++ b/lib/cities/country.rb
@@ -3,11 +3,11 @@ module ISO3166
   class Country
 
     def cities
-      City.cities_in_country(alpha2)
+      Cities.cities_in_country(alpha2)
     end
 
     def cities?
-      City.cities_in_country?(alpha2)
+      Cities.cities_in_country?(alpha2)
     end
 
   end

--- a/spec/city_spec.rb
+++ b/spec/city_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe City do
+describe Cities::City do
 
   context 'toronto' do
-    subject(:toronto) { City.cities_in_country('CA')['toronto'] }
-    it      { should be_a City }
+    subject(:toronto) { Cities.cities_in_country('CA')['toronto'] }
+    it      { should be_a Cities::City }
     specify { toronto.name.should eql 'Toronto' }
     specify { toronto.latitude.should be_a Float }
     specify { toronto.longitude.should be_a Float }
@@ -15,28 +15,28 @@ describe City do
   
   context 'dvadtsat' do
     subject(:dvadtsat) do
-      City.cities_in_country('TJ')["22 (dvadtsat' vtorogo) parts''yezd"]
+      Cities.cities_in_country('TJ')["22 (dvadtsat' vtorogo) parts''yezd"]
     end
-    it      { should be_a City }
+    it      { should be_a Cities::City }
     specify { dvadtsat.name.should eql "22 (Dvadtsat' Vtorogo) Parts''yezd" }
     specify { dvadtsat.population.should be_nil }
   end
 
   describe '::cities_in_country' do
-    subject { City.cities_in_country('US') }
+    subject { Cities.cities_in_country('US') }
 
     it      { should be_a Hash }
     specify { subject.keys.should include 'seattle' }
-    specify { subject['seattle'].should be_a City }
+    specify { subject['seattle'].should be_a Cities::City }
   end
 
   describe '::cities_in_country?' do
     it 'returns true for country with cities file' do
-      City.cities_in_country?('US').should be_true
+      Cities.cities_in_country?('US').should be_true
     end
 
     it 'returns false otherwise' do
-      City.cities_in_country?('XX').should be_false
+      Cities.cities_in_country?('XX').should be_false
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,6 @@ RSpec.configure do |config|
   config.order = 'random'
   config.formatter = :progress
   config.before(:all) do
-    City.data_path = ENV['DATA_PATH'] || File.expand_path('../../data/cities', __FILE__)
+    Cities.data_path = ENV['DATA_PATH'] || File.expand_path('../../data/cities', __FILE__)
   end
 end


### PR DESCRIPTION
- renames `City` class to `Cities::City` to keep every class in `Cities::`
  namespace (`City` is too general)
- moves static methods from `City` to `Cities`

README.md and speces have been updated.

Anyway - thanks for the gem! Small and very useful =)
